### PR TITLE
Move to native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ build = "build.rs"
 
 [dependencies]
 chrono = { version = "0.2", features = ["serde"] }
-hyper = "0.9"
+hyper = { version = "0.9", default-features = false }
+hyper-native-tls = "0.1"
 oauthcli = { version = "1", features = ["hyper"] }
 serde = "0.8"
 serde_json = "0.8"

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -7,7 +7,9 @@ use std::io::{copy, Read};
 use hyper::{self, header, mime, Get, Delete, Head};
 use hyper::client::Response;
 use hyper::method::Method;
+use hyper::net::HttpsConnector;
 use hyper::status::StatusClass;
+use hyper_native_tls::NativeTlsClient;
 use multipart::client::Multipart;
 use oauthcli;
 use url::{percent_encoding, Url};
@@ -101,13 +103,16 @@ pub trait HttpHandler {
 }
 
 pub struct DefaultHttpHandler {
-    pool: hyper::client::Pool<hyper::net::DefaultConnector>,
+    pool: hyper::client::Pool<HttpsConnector<NativeTlsClient>>,
 }
 
 impl DefaultHttpHandler {
     pub fn new() -> DefaultHttpHandler {
+        let tls = NativeTlsClient::new().unwrap();
+        let conn = HttpsConnector::new(tls);
+
         DefaultHttpHandler {
-            pool: hyper::client::Pool::new(Default::default()),
+            pool: hyper::client::Pool::with_connector(Default::default(), conn),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 
 pub extern crate chrono;
 pub extern crate hyper;
+extern crate hyper_native_tls;
 extern crate multipart;
 extern crate oauthcli;
 extern crate serde;


### PR DESCRIPTION
Currently, the library is depending (through hyper's default feature) on `openssl` v0.7, which is not the latest version available (v0.9). This causes a compilation error when the user is explicitly depending on another version of `openssl`.

This PR removes the direct dependency on `openssl` and instead introduces `native-tls` as the TLS implementation. It considerably mitigates the compatibility issue above because it uses the latest `openssl` v0.9 or platform-native TLS implementation if one is available.

Note that this is a breaking change if the user is explicitly depending on `openssl` v0.7.