### PR TITLE
Update chrono to v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ include = ["**/*.rs", "**/Cargo.toml", "LICENSE.txt", "README.md", "CoreTweet/Ap
 build = "build.rs"
 
 [dependencies]
-chrono = { version = "0.3.1", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 hyper = "0.10"
 hyper-native-tls = { version = "0.2", optional = true }
 oauthcli = "1"

--- a/src/models/places.rs
+++ b/src/models/places.rs
@@ -99,8 +99,8 @@ pub struct PlaceType {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TrendsResult {
-    pub as_of: chrono::DateTime<chrono::UTC>,
-    pub created_at: chrono::DateTime<chrono::UTC>,
+    pub as_of: chrono::DateTime<chrono::Utc>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
     pub locations: Vec<TrendLocation>,
     pub trends: Vec<Trend>,
 }

--- a/src/models/rate_limit.rs
+++ b/src/models/rate_limit.rs
@@ -6,9 +6,9 @@ pub struct RateLimitStatus {
 }
 
 impl RateLimitStatus {
-    pub fn reset_date_time(&self) -> chrono::DateTime<chrono::UTC> {
+    pub fn reset_date_time(&self) -> chrono::DateTime<chrono::Utc> {
         use chrono::TimeZone;
-        chrono::UTC.timestamp(self.reset, 0)
+        chrono::Utc.timestamp(self.reset, 0)
     }
 }
 


### PR DESCRIPTION
Version `0.3.1` of `chrono` crate has been yanked. Unfortunately, that made it impossible for `tweetust` `0.7` to compile successfully.

So this PR updates `chrono` to version [`0.4`](https://github.com/chronotope/chrono/blob/v0.4.0/CHANGELOG.md#040-2017-06-22), which should fix the compile error.